### PR TITLE
UI improvements for the overview

### DIFF
--- a/css/scss/main.scss
+++ b/css/scss/main.scss
@@ -38,7 +38,8 @@ body {
 			&:hover {
 				.info {
 					background: rgba(0,0,0,0.6);
-					transition: background 0.3s;
+					opacity: 1;
+					transition: background,opacity 0.3s;
 				}
 				.description {
 					display: block; 
@@ -56,6 +57,7 @@ body {
 				position: absolute;
 				bottom: 0;
 				width: 100%;
+				opacity: 0.5;
 			}
 			.name {
 				display: inline-block; 

--- a/css/scss/main.scss
+++ b/css/scss/main.scss
@@ -40,6 +40,9 @@ body {
 					background: rgba(0,0,0,0.6);
 					transition: background 0.3s;
 				}
+				.description {
+					display: block; 
+				}
 			}
 			a.files {
 				background-size: cover;
@@ -67,6 +70,7 @@ body {
 				font-weight: 300; 
 				text-shadow: 1px 1px 0 rgba(0,0,0,1);
 				line-height: 1.2;
+				display: none;
 			}
 		}
 	}


### PR DESCRIPTION
3915971 closes #6 . I choose to show the description when hovering the photo, because I think it's nice to be able to see the description quickly when without having to open the fullscreen viewer. 
I added 9f3b308 to have the info area take up less focus when browsing the overview, making the photos more centerpiece.